### PR TITLE
docs: add RunScript guidance to MCP core skill

### DIFF
--- a/plugins/alibabacloud-core/.claude-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "license": "Apache-2.0",
   "name": "alibabacloud-core",
   "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
-  "version": "1.0.12"
+  "version": "1.0.13"
 }

--- a/plugins/alibabacloud-core/.codex-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-core",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Core Alibaba Cloud plugin for OpenAPI SDK code generation through a constrained MCP server.",
   "author": {
     "name": "Alibaba Cloud"

--- a/plugins/alibabacloud-core/skills/mcp-core-best-practices/SKILL.md
+++ b/plugins/alibabacloud-core/skills/mcp-core-best-practices/SKILL.md
@@ -3,9 +3,10 @@ name: mcp-core-best-practices
 description: >
   Shared reference for using Alibaba Cloud OpenAPI MCP Server Core effectively.
   Covers tool usage patterns, API exploration workflow, CLI command generation,
-  cross-account access, and safety policy configuration. Referenced by other
-  alibabacloud-core skills as the canonical guide for MCP Core interactions.
-allowed-tools: "mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___CallCLI,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___SearchApis,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___GetApiDefinition,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___ListApis,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___ListProductRegions,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___GenerateCLICommand,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___ListProducts,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___SearchDocument,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___ReadDocument"
+  scripted execution, async task polling, cross-account access, and safety policy
+  configuration. Referenced by other alibabacloud-core skills as the canonical
+  guide for MCP Core interactions.
+allowed-tools: "mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___CallCLI,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___SearchApis,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___GetApiDefinition,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___ListApis,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___ListProductRegions,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___GenerateCLICommand,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___ListProducts,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___SearchDocument,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___ReadDocument,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___RunScript,mcp__plugin_alibabacloud-core_alibabacloud-core__AlibabaCloud___GetTask"
 ---
 
 # Alibaba Cloud MCP Core Best Practices
@@ -27,6 +28,8 @@ APIs without requiring pre-selection of specific operations.
 | `AlibabaCloud___ListProducts` | List all Alibaba Cloud products |
 | `AlibabaCloud___SearchDocument` | Search Alibaba Cloud documentation by keyword |
 | `AlibabaCloud___ReadDocument` | Read a specific documentation page by URL |
+| `AlibabaCloud___RunScript` | Start a restricted Python task with structured Alibaba Cloud OpenAPI access |
+| `AlibabaCloud___GetTask` | Long-poll a `RunScript` task until approval, execution, or failure reaches a terminal state |
 
 ## Standard Workflow
 
@@ -54,7 +57,24 @@ retrieve the full definition including:
 Use `AlibabaCloud___GenerateCLICommand` to produce a correct CLI command from the
 API definition and user-provided parameters. This avoids manual CLI syntax errors.
 
-### 4. Execution
+### 4. Execution Choice
+
+Use `AlibabaCloud___CallCLI` for one known `aliyun ...` command when no later
+call depends on its response. Verified example:
+`AlibabaCloud___CallCLI(command="aliyun ecs DescribeRegions --region cn-hangzhou")`.
+
+Use `AlibabaCloud___RunScript` when the answer needs structured OpenAPI
+`call_cli(...)`: pagination, List-to-Describe enrichment, cross-resource
+comparison, multi-region/multi-product collection, permission checks, OSS
+body/bytes handling, response-driven follow-up calls, or custom result shaping.
+Example: fetch identity, list resources, and perform follow-up Describe/Get
+calls in one script instead of separate tool round-trips.
+
+Do not split one user task across multiple `RunScript` submissions just to
+inspect intermediate data. Put discovery, pagination, filtering, and follow-up
+Describe/Get calls in one self-contained script and return via `result`.
+
+### 5. Single-Call Execution
 
 Use `AlibabaCloud___CallCLI` to execute the generated command. Key constraints:
 
@@ -63,7 +83,102 @@ Use `AlibabaCloud___CallCLI` to execute the generated command. Key constraints:
 - No shell variables or command substitution
 - No local file path references (MCP server is remote)
 
-### 5. Cross-Account Execution
+### 6. Scripted Multi-Call Execution
+
+`AlibabaCloud___RunScript` starts a sandboxed Python task and waits up to 20
+seconds. It may return `result` directly; otherwise use the returned `processID`
+and `nextAction` with `AlibabaCloud___GetTask`. The script's OpenAPI access goes
+through injected `call_cli()` only:
+
+```python
+identity = await call_cli(product='Sts', action='GetCallerIdentity',
+                          params={}, version='2015-04-01')
+result = {'has_account_id': 'AccountId' in identity}
+```
+
+RunScript essentials:
+
+- `call_cli()` is structured OpenAPI, not CLI text. Never pass `aliyun ...`.
+- Before unfamiliar APIs, OSS APIs, body/object params, array params, or
+  parameter retries, call `AlibabaCloud___GetApiDefinition` separately.
+- Top-level `params` keys must match OpenMeta `parameters[].name`. RPC APIs
+  often use `RegionId`; OSS APIs often use `bucket`, `max-keys`, `x-oss-acl`,
+  or `body`.
+- Arrays/objects stay as Python lists/dicts unless the API parameter itself is
+  JSON text.
+- For OSS object bytes, `PutObject` accepts bytes in `params['body']` and
+  `GetObject` returns bytes in `Body`.
+- `version`, `region`, and `endpoint` are optional; still pass API region fields
+  such as `RegionId` when the API defines them.
+- Assign final output to `result`. Do not pass credentials, profiles, shell
+  flags, or host file paths. Use `/tmp` only for small sandbox scratch files.
+- The script must have a reachable module-level `call_cli()`; pure Python
+  payloads fail validation.
+- Do not write `import` or comments. Safe modules such as `asyncio`, `json`,
+  `math`, `re`, `time`, and `uuid` are pre-imported.
+- Do not use sensitive names such as `eval`, `exec`, `compile`, `__import__`,
+  `globals`, `locals`, `getattr`, `setattr`, or `vars`; do not use private or
+  dunder attributes, dynamic `.format()` tricks, subprocesses, or network code.
+- Do not target CLI meta products such as `configure`, `plugin`, `ossutil`,
+  `ossutil64`, `upgrade`, or `mock`. Some OSS APIs are unsupported; if the
+  validator returns `UnsupportedOssApi`, choose a supported OSS OpenAPI action
+  or another tool.
+- Discover IDs inside the script, paginate every list call, and never sample or
+  truncate complete inventory/compliance answers.
+- List APIs are not enough for attribute checks. Follow List with Describe/Get
+  and feature-specific APIs for every resource.
+- Verify response shape before saying "0 found"; list responses often wrap arrays
+  twice, e.g. `{"Instances":{"Instance":[...]}}`.
+- Use `asyncio.gather(..., return_exceptions=True)` for parallel calls. Treat
+  expected NotFound as "not configured" for optional features.
+- Do exact aggregation in Python; return raw fields for judgment calls such as
+  "misconfigured" or "risky".
+
+OSS object read/write example (use a user-approved temporary bucket/key):
+
+```python
+bucket = '<approved-bucket>'
+key = 'run-script-probe/example.txt'
+content = b'hello-from-run-script\n'
+put = await call_cli(product='Oss', action='PutObject',
+                     params={'bucket': bucket, 'key': key, 'body': content},
+                     version='2019-05-17', region='cn-hangzhou')
+got = await call_cli(product='Oss', action='GetObject',
+                     params={'bucket': bucket, 'key': key},
+                     version='2019-05-17', region='cn-hangzhou')
+result = {'put_ok': isinstance(put, dict), 'round_trip_ok': got.get('Body') == content}
+```
+
+### 7. RunScript Task Polling
+
+After `AlibabaCloud___RunScript`, inspect `nextAction`:
+
+| `nextAction` | Meaning | Agent action |
+|--------------|---------|--------------|
+| `None` | Task succeeded | Use `result` |
+| `CallGetTask` | Initial call is not terminal | Call `AlibabaCloud___GetTask` with the same `processID` |
+| `CallGetTaskAgain` | Poll timed out and task is still not terminal | Call `AlibabaCloud___GetTask` again with the same `processID` |
+| `Stop` | Validation failed, approval rejected/expired, task expired, or process missing | Stop; do not retry automatically |
+| `InspectError` | Execution failed | Inspect `error`; failed OpenAPI calls appear in `error.failedCall` when available |
+
+`AlibabaCloud___GetTask` parameters:
+
+- `processID`: required, from `RunScript`.
+- `waitTimeoutSeconds`: optional, capped at 30 seconds by the server. Use `0`
+  for an immediate status check.
+- `pollIntervalSeconds`: optional polling interval, between 1 and 10 seconds.
+
+Human approval handling:
+
+- `ApprovalPending` with `approvalReqId` means external approval is required.
+  Ask the user to complete approval or rejection out of band, then call
+  `AlibabaCloud___GetTask` again with the same `processID`.
+- Do not call `AlibabaCloud___RunScript` again while waiting for approval or
+  execution; that creates a new process instead of continuing the current one.
+- `ApprovalRejected` and `ApprovalExpired` are terminal. Stop and report the
+  approval result.
+
+### 8. Cross-Account Execution
 
 **IMPORTANT**: For any operation involving member accounts, cross-account queries,
 or Resource Directory account resolution, you MUST first load the
@@ -120,6 +235,12 @@ that are not captured in API definitions alone.
 - **AccessDenied / Forbidden**: Verify RAM permissions for the current identity.
 - **Throttling**: Retry with backoff; do not loop aggressively.
 - **RegionNotSupported**: Use `ListProductRegions` to find valid regions.
+- **RunScript ValidationFailed**: Fix unsafe or invalid Python authoring patterns
+  before submitting a new `RunScript`.
+- **RunScript BLK-4002**: Add a reachable module-level `call_cli()`; pure Python
+  scripts are rejected.
+- **RunScript Failed / InspectError**: Inspect `error`; if the script needs
+  correction, submit one new corrected `RunScript`.
 
 ## Skill Discovery (Fallback)
 
@@ -172,8 +293,10 @@ When building stable workflows:
 
 1. Use `SearchApis` to identify the correct API during development.
 2. Use `GenerateCLICommand` to produce validated commands.
-3. Capture the stable command patterns into a dedicated Skill.
-4. Configure a safety policy to restrict the MCP connection to only the commands
+3. Use `RunScript` for workflows that require complete pagination,
+   List-to-Describe enrichment, or multi-call analysis.
+4. Capture the stable command or script patterns into a dedicated Skill.
+5. Configure a safety policy to restrict the MCP connection to only the commands
    the Skill needs (for production use).
 
 This progression — explore, validate, codify, restrict — ensures both flexibility


### PR DESCRIPTION
## Summary
- Add guidance for choosing CallCLI vs RunScript in the MCP core best-practices skill.
- Document RunScript parameter rules, forbidden patterns, and GetTask polling semantics.
- Add verified STS and OSS object read/write RunScript examples.

## Verification
- python3 tools/validate.py
- git diff --check
- markdownlint-cli2 on plugins/alibabacloud-core/skills/mcp-core-best-practices/SKILL.md
- Live MCP verification for CallCLI, STS RunScript, OSS PutObject/GetObject round trip, and import rejection.