### PR TITLE
chore(plugin): bump alibabacloud-core 1.0.12 -> 1.0.14

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       ],
       "name": "alibabacloud-core",
       "source": "./plugins/alibabacloud-core",
-      "version": "1.0.12"
+      "version": "1.0.14"
     },
     {
       "category": "cloud",

--- a/plugins/alibabacloud-core/.claude-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "license": "Apache-2.0",
   "name": "alibabacloud-core",
   "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
-  "version": "1.0.13"
+  "version": "1.0.14"
 }

--- a/plugins/alibabacloud-core/.codex-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-core",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Core Alibaba Cloud plugin for OpenAPI SDK code generation through a constrained MCP server.",
   "author": {
     "name": "Alibaba Cloud"


### PR DESCRIPTION
Aone 83609463:给 alibabacloud-core 升一个小版本到 1.0.13。

- .claude-plugin/plugin.json 1.0.12→1.0.13
- .codex-plugin/plugin.json 1.0.12→1.0.13
- .claude-plugin/marketplace.json core 条目 1.0.10→1.0.13

validate.py 全绿。
