### PR TITLE
feat(plugin): add Qoder client plugin support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       ],
       "name": "alibabacloud-core",
       "source": "./plugins/alibabacloud-core",
-      "version": "1.0.15"
+      "version": "1.0.16"
     },
     {
       "category": "cloud",
@@ -35,7 +35,7 @@
       ],
       "name": "alibabacloud-spec-ops",
       "source": "./plugins/alibabacloud-spec-ops",
-      "version": "0.1.2"
+      "version": "0.1.3"
     }
   ]
 }

--- a/plugins/alibabacloud-core/.claude-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "license": "Apache-2.0",
   "name": "alibabacloud-core",
   "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
-  "version": "1.0.15"
+  "version": "1.0.16"
 }

--- a/plugins/alibabacloud-core/.codex-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-core",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Core Alibaba Cloud plugin for OpenAPI SDK code generation through a constrained MCP server.",
   "author": {
     "name": "Alibaba Cloud"

--- a/plugins/alibabacloud-core/.qoder-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.qoder-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "alibabacloud-core",
+  "version": "1.0.16",
+  "description": "Core Alibaba Cloud plugin for OpenAPI SDK code generation through a constrained MCP server.",
+  "displayName": "Alibaba Cloud Core",
+  "author": {
+    "name": "Alibaba Cloud"
+  },
+  "keywords": [
+    "alibabacloud",
+    "aliyun"
+  ],
+  "homepage": "https://github.com/aliyun/alibabacloud-agent-toolkit",
+  "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
+  "license": "Apache-2.0",
+  "skills": "./skills/",
+  "hooks": "./hooks/qoderwork-hooks.json",
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/alibabacloud-core/hooks/qoderwork-hooks.json
+++ b/plugins/alibabacloud-core/hooks/qoderwork-hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "name": "alibabacloud-core/pre-tool-trace",
-            "command": "QODER_WORK=1 bash \"__PLUGIN_ROOT__/hooks/scripts/pre-tool-trace.sh\"",
+            "command": "QODER_WORK=1 bash \"${QODER_PLUGIN_ROOT}/hooks/scripts/pre-tool-trace.sh\"",
             "timeout": 3,
             "statusMessage": "alibabacloud trace: pre"
           }
@@ -21,7 +21,7 @@
           {
             "type": "command",
             "name": "alibabacloud-core/post-tool-trace",
-            "command": "QODER_WORK=1 bash \"__PLUGIN_ROOT__/hooks/scripts/post-tool-trace.sh\"",
+            "command": "QODER_WORK=1 bash \"${QODER_PLUGIN_ROOT}/hooks/scripts/post-tool-trace.sh\"",
             "timeout": 15,
             "statusMessage": "alibabacloud trace: post"
           }
@@ -34,7 +34,7 @@
           {
             "type": "command",
             "name": "alibabacloud-core/prompt-trace",
-            "command": "QODER_WORK=1 bash \"__PLUGIN_ROOT__/hooks/scripts/prompt-trace.sh\"",
+            "command": "QODER_WORK=1 bash \"${QODER_PLUGIN_ROOT}/hooks/scripts/prompt-trace.sh\"",
             "timeout": 5,
             "statusMessage": "alibabacloud trace: prompt"
           }
@@ -47,7 +47,7 @@
           {
             "type": "command",
             "name": "alibabacloud-core/stop-turn-increment",
-            "command": "QODER_WORK=1 bash \"__PLUGIN_ROOT__/hooks/scripts/stop-turn-increment.sh\"",
+            "command": "QODER_WORK=1 bash \"${QODER_PLUGIN_ROOT}/hooks/scripts/stop-turn-increment.sh\"",
             "timeout": 15,
             "statusMessage": "alibabacloud trace: stop"
           }

--- a/plugins/alibabacloud-spec-ops/.claude-plugin/plugin.json
+++ b/plugins/alibabacloud-spec-ops/.claude-plugin/plugin.json
@@ -17,5 +17,5 @@
   "license": "Apache-2.0",
   "name": "alibabacloud-spec-ops",
   "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
-  "version": "0.1.2"
+  "version": "0.1.3"
 }

--- a/plugins/alibabacloud-spec-ops/.codex-plugin/plugin.json
+++ b/plugins/alibabacloud-spec-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-spec-ops",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Alibaba Cloud AI Ops Plugin - Infrastructure operations workflow with intelligent planning, validation, and execution powered by MCP tooling",
   "author": {
     "name": "Alibaba Cloud"

--- a/plugins/alibabacloud-spec-ops/.qoder-plugin/plugin.json
+++ b/plugins/alibabacloud-spec-ops/.qoder-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "alibabacloud-spec-ops",
+  "version": "0.1.3",
+  "description": "Alibaba Cloud AI Ops Plugin - Infrastructure operations workflow with intelligent planning, validation, and execution powered by MCP tooling.",
+  "displayName": "Alibaba Cloud AI Spec Ops",
+  "author": {
+    "name": "Alibaba Cloud"
+  },
+  "keywords": [
+    "alibabacloud",
+    "aliyun",
+    "cloud",
+    "infrastructure",
+    "terraform",
+    "iac",
+    "ops",
+    "devops"
+  ],
+  "homepage": "https://github.com/aliyun/alibabacloud-agent-toolkit",
+  "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
+  "license": "Apache-2.0",
+  "skills": "./skills/",
+  "agents": "./agents/",
+  "hooks": "./hooks/qoderwork-hooks.json",
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/alibabacloud-spec-ops/hooks/qoderwork-hooks.json
+++ b/plugins/alibabacloud-spec-ops/hooks/qoderwork-hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "name": "alibabacloud-core/pre-tool-trace",
-            "command": "QODER_WORK=1 bash \"__PLUGIN_ROOT__/hooks/scripts/pre-tool-trace.sh\"",
+            "command": "QODER_WORK=1 bash \"${QODER_PLUGIN_ROOT}/hooks/scripts/pre-tool-trace.sh\"",
             "timeout": 3,
             "statusMessage": "alibabacloud trace: pre"
           }
@@ -21,7 +21,7 @@
           {
             "type": "command",
             "name": "alibabacloud-core/post-tool-trace",
-            "command": "QODER_WORK=1 bash \"__PLUGIN_ROOT__/hooks/scripts/post-tool-trace.sh\"",
+            "command": "QODER_WORK=1 bash \"${QODER_PLUGIN_ROOT}/hooks/scripts/post-tool-trace.sh\"",
             "timeout": 15,
             "statusMessage": "alibabacloud trace: post"
           }
@@ -34,7 +34,7 @@
           {
             "type": "command",
             "name": "alibabacloud-core/prompt-trace",
-            "command": "QODER_WORK=1 bash \"__PLUGIN_ROOT__/hooks/scripts/prompt-trace.sh\"",
+            "command": "QODER_WORK=1 bash \"${QODER_PLUGIN_ROOT}/hooks/scripts/prompt-trace.sh\"",
             "timeout": 5,
             "statusMessage": "alibabacloud trace: prompt"
           }
@@ -47,7 +47,7 @@
           {
             "type": "command",
             "name": "alibabacloud-core/stop-turn-increment",
-            "command": "QODER_WORK=1 bash \"__PLUGIN_ROOT__/hooks/scripts/stop-turn-increment.sh\"",
+            "command": "QODER_WORK=1 bash \"${QODER_PLUGIN_ROOT}/hooks/scripts/stop-turn-increment.sh\"",
             "timeout": 15,
             "statusMessage": "alibabacloud trace: stop"
           }


### PR DESCRIPTION
Add .qoder-plugin/plugin.json for alibabacloud-core and alibabacloud-spec-ops to support the Qoder client plugin discovery and loading mechanism. Switch qoderwork-hooks.json to the official ${QODER_PLUGIN_ROOT} variable.

- bump alibabacloud-core 1.0.15 -> 1.0.16
- bump alibabacloud-spec-ops 0.1.2 -> 0.1.3

(created by caihe-agent)

## Description

<!-- Describe the changes in this PR -->

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [x] Documentation update
- [ ] CI/CD change
- [x] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ x My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
