### PR TITLE
fix(hooks): resolve false duplicate rejection for qoderwork telemetry

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       ],
       "name": "alibabacloud-core",
       "source": "./plugins/alibabacloud-core",
-      "version": "1.0.16"
+      "version": "1.0.17"
     },
     {
       "category": "cloud",
@@ -35,7 +35,7 @@
       ],
       "name": "alibabacloud-spec-ops",
       "source": "./plugins/alibabacloud-spec-ops",
-      "version": "0.1.3"
+      "version": "0.1.4"
     }
   ]
 }

--- a/plugins/alibabacloud-core/.claude-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "license": "Apache-2.0",
   "name": "alibabacloud-core",
   "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
-  "version": "1.0.16"
+  "version": "1.0.17"
 }

--- a/plugins/alibabacloud-core/.codex-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-core",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Core Alibaba Cloud plugin for OpenAPI SDK code generation through a constrained MCP server.",
   "author": {
     "name": "Alibaba Cloud"

--- a/plugins/alibabacloud-core/.qoder-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.qoder-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-core",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Core Alibaba Cloud plugin for OpenAPI SDK code generation through a constrained MCP server.",
   "displayName": "Alibaba Cloud Core",
   "author": {

--- a/plugins/alibabacloud-core/hooks/scripts/lib/post_handler.py
+++ b/plugins/alibabacloud-core/hooks/scripts/lib/post_handler.py
@@ -30,7 +30,7 @@ PLUGIN_PREFIX = "alibabacloud"
 STDIN_CAP = 10 * 1024 * 1024  # 10 MB — full response bodies can legitimately exceed 64 KB
 JSON_PARSE_WINDOW = 16384
 ERROR_REGEX_WINDOW = 500
-QODERWORK_MCP_WRAPPERS = ("qw_mcp_call", "qw_mcp_get")
+QODERWORK_MCP_WRAPPERS = ("qw_mcp_call", "qw_mcp_get", "CallMcpTool")
 
 
 def detect_client(payload_str: str) -> str:
@@ -777,13 +777,24 @@ def main() -> int:
     start_ms = None
     turn = 0
     duplicate_skipped = False
+    unique_span_key = tool_use_id or marker_key
     if session_id:
         try:
             with SessionState(client, session_id) as st:
                 # Dedup: some clients (claude-code) fire PostToolUse twice
                 # for the same Skill call. Without dedup we'd emit duplicate
                 # trace events and double-upload to remote telemetry.
-                dedup_key = tool_use_id or f"{tool_name}:{marker_key}"
+                # When tool_use_id is present, it uniquely identifies a call
+                # so repeated fires of the same ID are true duplicates.
+                # When tool_use_id is absent (e.g. qoderwork), each fire is
+                # a distinct call — use a monotonic seq to avoid false dedup.
+                if tool_use_id:
+                    dedup_key = tool_use_id
+                else:
+                    _seq = st.data.get("_post_seq", 0) + 1
+                    st.data["_post_seq"] = _seq
+                    dedup_key = f"{tool_name}:{_seq}"
+                    unique_span_key = dedup_key
                 posted = st.data.setdefault("posted_tool_use_ids", [])
                 if dedup_key in posted:
                     duplicate_skipped = True
@@ -896,7 +907,7 @@ def main() -> int:
         "cli-command": seed.get("cli_command", ""),
         "event-tag": event_tag,
         "error-message": error_message,
-        "span-id": tool_use_id or marker_key,
+        "span-id": unique_span_key,
         "parent-span-id": parent_span_id,
         "skill-tag": _path_skill_tag(tool_input) or "",
         "mcp-session-id": _read_mcp_session_id(),
@@ -910,7 +921,7 @@ def main() -> int:
     if trace_writer.trace_enabled() and session_id:
         try:
             parent_span = None
-            this_span_id = tool_use_id or marker_key
+            this_span_id = unique_span_key
             try:
                 with SessionState(client, session_id) as st:
                     # Reuse the parent that pre-tool-trace stamped into
@@ -962,7 +973,7 @@ def main() -> int:
                 response_data, was_truncated = trace_writer.truncate_response(trace_response)
                 trace_writer.append_trace(client, session_id, {
                     "event": "tool_end",
-                    "span_id": tool_use_id or marker_key,
+                    "span_id": unique_span_key,
                     "parent_span_id": parent_span,
                     "tool_name": tool_name,
                     "tool_use_id": tool_use_id,

--- a/plugins/alibabacloud-core/hooks/scripts/lib/pre_handler.py
+++ b/plugins/alibabacloud-core/hooks/scripts/lib/pre_handler.py
@@ -20,7 +20,7 @@ import trace_writer  # noqa: E402
 
 PLUGIN_PREFIX = "alibabacloud"
 STDIN_CAP = 65536
-QODERWORK_MCP_WRAPPERS = ("qw_mcp_call", "qw_mcp_get")
+QODERWORK_MCP_WRAPPERS = ("qw_mcp_call", "qw_mcp_get", "CallMcpTool")
 
 # Aliyun CLI invocation: matches `aliyun ...` at start of command OR
 # after a shell separator (`&&`, `||`, `;`, `|`, `\n`, `(`), with optional
@@ -170,24 +170,36 @@ def main() -> int:
     parent_span = None
     turn = 0
     is_duplicate = False
+    unique_span_key = tool_use_id or key
     try:
         with SessionState(client, session_id) as st:
             st.data["tool_starts"][key] = int(time.time() * 1000)
             # --- Local trace: mark turn active, get parent span ---
             if trace_writer.trace_enabled():
                 st.data["turn_has_trace"] = True
-                this_span_id = tool_use_id or key
                 # Dedup: Claude fires PreToolUse twice for the same
                 # tool_use_id within one turn (symmetric with the
                 # PostToolUse dedup via posted_tool_use_ids). Skip the
                 # second fire so we neither write a duplicate tool_start
                 # event nor a duplicate turn_spans entry.
+                # When tool_use_id is present, it uniquely identifies a
+                # call so repeated fires of the same ID are true duplicates.
+                # When tool_use_id is absent (e.g. qoderwork), each fire is
+                # a distinct call — use a monotonic seq to avoid false dedup.
+                if tool_use_id:
+                    dedup_key = tool_use_id
+                else:
+                    _seq = st.data.get("_pre_seq", 0) + 1
+                    st.data["_pre_seq"] = _seq
+                    dedup_key = f"{tool_name}:{_seq}"
+                    unique_span_key = dedup_key
                 pre_seen = st.data.setdefault("pre_seen_ids", [])
-                if this_span_id and this_span_id in pre_seen:
+                if dedup_key in pre_seen:
                     is_duplicate = True
                 else:
-                    if this_span_id:
-                        pre_seen.append(this_span_id)
+                    pre_seen.append(dedup_key)
+                    if len(pre_seen) > 500:
+                        pre_seen[:] = pre_seen[-500:]
                     # All tool spans parent directly to the prompt span.
                     # Skill association is content-based — see post_handler
                     # ._path_skill_tag (matches the bash command's UA env
@@ -197,7 +209,7 @@ def main() -> int:
                     turn = int(st.data.get("turn", 0))
                     # Record this span for end-of-turn token aggregation
                     st.data.setdefault("turn_spans", []).append({
-                        "span_id": this_span_id,
+                        "span_id": unique_span_key,
                         "parent_span_id": parent_span,
                         "kind": "tool",
                         "tool_use_id": tool_use_id,
@@ -220,7 +232,7 @@ def main() -> int:
             now_ms = int(time.time() * 1000)
             trace_writer.append_trace(client, session_id, {
                 "event": "tool_start",
-                "span_id": tool_use_id or key,
+                "span_id": unique_span_key,
                 "parent_span_id": parent_span,
                 "tool_name": tool_name,
                 "tool_use_id": tool_use_id,

--- a/plugins/alibabacloud-core/hooks/scripts/post-tool-trace.sh
+++ b/plugins/alibabacloud-core/hooks/scripts/post-tool-trace.sh
@@ -5,6 +5,7 @@
 set +e
 umask 077
 
+
 return_success() {
     echo '{"continue":true}'
     exit 0
@@ -83,6 +84,15 @@ payload=$(head -c 65536)
 client=$(detect_client_bash "$payload")
 cdir=$(state_dir_for_client "$client")
 
+# Dump raw payload to debug.log for diagnosis
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    {
+        printf '[%s] [post-tool] raw-payload (%d bytes):\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${#payload}"
+        printf '%s\n' "$payload" | head -c 4096
+        printf '\n---end-payload---\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+fi
+
 # Optional raw-payload trace: dump full stdin to a file so future bugs
 # can be diagnosed without guessing at the payload shape.
 if [ "${ALIBABACLOUD_TELEMETRY_TRACE_PAYLOAD}" = "1" ]; then
@@ -149,8 +159,29 @@ fi
 
 # Fire-and-forget: detach so the agent loop never waits on uvx.
 debug_log "$cdir" "decision=upload event=$(extract_arg --event-type "${args[@]}") tool=$(extract_arg --tool-name "${args[@]}")"
-( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
-    </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
-disown 2>/dev/null
+
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    # Debug mode: capture uvx output for diagnosis instead of discarding
+    {
+        printf '[%s] [post-tool] upload-start cmd=uvx alibabacloud.mcp-proxy@latest plugin-telemetry' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        for a in "${args[@]}"; do printf ' %q' "$a"; done
+        printf '\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+    (
+        uvx_out=$(uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" </dev/null 2>&1)
+        uvx_rc=$?
+        {
+            printf '[%s] [post-tool] upload-done rc=%d\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_rc"
+            if [ -n "$uvx_out" ]; then
+                printf '[%s] [post-tool] upload-output: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_out"
+            fi
+        } >> "$cdir/debug.log" 2>/dev/null
+    ) &
+    disown 2>/dev/null
+else
+    ( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
+        </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
+    disown 2>/dev/null
+fi
 
 return_success

--- a/plugins/alibabacloud-core/hooks/scripts/pre-tool-trace.sh
+++ b/plugins/alibabacloud-core/hooks/scripts/pre-tool-trace.sh
@@ -4,6 +4,7 @@
 set +e
 umask 077
 
+
 detect_client_bash() {
     if [ "$COPILOT_CLI" = "1" ]; then echo "copilot-cli"; return; fi
     if [ "$CODEX_CLI" = "1" ]; then echo "codex"; return; fi
@@ -58,6 +59,15 @@ scriptDir="$(cd "$(dirname "$0")" && pwd)"
 payload=$(head -c 65536)
 client=$(detect_client_bash "$payload")
 cdir=$(state_dir_for_client "$client")
+
+# Dump raw payload to debug.log for diagnosis
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    {
+        printf '[%s] [pre-tool] raw-payload (%d bytes):\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${#payload}"
+        printf '%s\n' "$payload" | head -c 4096
+        printf '\n---end-payload---\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+fi
 
 if [ "${ALIBABACLOUD_TELEMETRY_TRACE_PAYLOAD}" = "1" ]; then
     payloadDir="$cdir/raw-payloads"

--- a/plugins/alibabacloud-core/hooks/scripts/prompt-trace.sh
+++ b/plugins/alibabacloud-core/hooks/scripts/prompt-trace.sh
@@ -7,6 +7,7 @@
 set +e
 umask 077
 
+
 return_success() {
     echo '{"continue":true}'
     exit 0
@@ -85,6 +86,15 @@ payload=$(head -c 65536)
 client=$(detect_client_bash "$payload")
 cdir=$(state_dir_for_client "$client")
 
+# Dump raw payload to debug.log for diagnosis
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    {
+        printf '[%s] [prompt] raw-payload (%d bytes):\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${#payload}"
+        printf '%s\n' "$payload" | head -c 4096
+        printf '\n---end-payload---\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+fi
+
 # Optional raw-payload trace: dump full stdin to a file so future bugs
 # can be diagnosed without guessing at the payload shape.
 if [ "${ALIBABACLOUD_TELEMETRY_TRACE_PAYLOAD}" = "1" ]; then
@@ -152,8 +162,29 @@ fi
 
 # Fire-and-forget: detach so the agent loop never waits on uvx.
 debug_log "$cdir" "decision=upload skill=$(extract_arg --skill-name "${args[@]}")"
-( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
-    </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
-disown 2>/dev/null
+
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    # Debug mode: capture uvx output for diagnosis instead of discarding
+    {
+        printf '[%s] [prompt] upload-start cmd=uvx alibabacloud.mcp-proxy@latest plugin-telemetry' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        for a in "${args[@]}"; do printf ' %q' "$a"; done
+        printf '\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+    (
+        uvx_out=$(uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" </dev/null 2>&1)
+        uvx_rc=$?
+        {
+            printf '[%s] [prompt] upload-done rc=%d\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_rc"
+            if [ -n "$uvx_out" ]; then
+                printf '[%s] [prompt] upload-output: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_out"
+            fi
+        } >> "$cdir/debug.log" 2>/dev/null
+    ) &
+    disown 2>/dev/null
+else
+    ( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
+        </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
+    disown 2>/dev/null
+fi
 
 return_success

--- a/plugins/alibabacloud-core/hooks/scripts/stop-turn-increment.sh
+++ b/plugins/alibabacloud-core/hooks/scripts/stop-turn-increment.sh
@@ -8,6 +8,7 @@
 set +e
 umask 077
 
+
 if [ "${ALIBABACLOUD_TELEMETRY}" = "false" ]; then
     exit 0
 fi
@@ -74,6 +75,15 @@ payload=$(head -c 65536)
 client=$(detect_client_bash "$payload")
 cdir=$(state_dir_for_client "$client")
 
+# Dump raw payload to debug.log for diagnosis
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    {
+        printf '[%s] [stop] raw-payload (%d bytes):\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${#payload}"
+        printf '%s\n' "$payload" | head -c 4096
+        printf '\n---end-payload---\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+fi
+
 if [ "${ALIBABACLOUD_TELEMETRY_TRACE_PAYLOAD}" = "1" ]; then
     payloadDir="$cdir/raw-payloads"
     mkdir -p "$payloadDir" 2>/dev/null && chmod 700 "$payloadDir" 2>/dev/null
@@ -134,8 +144,29 @@ fi
 
 # Fire-and-forget: detach so the agent loop never waits on uvx.
 debug_log "$cdir" "[stop] decision=upload event=$(extract_arg --event-type "${args[@]}")"
-( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
-    </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
-disown 2>/dev/null
+
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    # Debug mode: capture uvx output for diagnosis instead of discarding
+    {
+        printf '[%s] [stop] upload-start cmd=uvx alibabacloud.mcp-proxy@latest plugin-telemetry' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        for a in "${args[@]}"; do printf ' %q' "$a"; done
+        printf '\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+    (
+        uvx_out=$(uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" </dev/null 2>&1)
+        uvx_rc=$?
+        {
+            printf '[%s] [stop] upload-done rc=%d\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_rc"
+            if [ -n "$uvx_out" ]; then
+                printf '[%s] [stop] upload-output: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_out"
+            fi
+        } >> "$cdir/debug.log" 2>/dev/null
+    ) &
+    disown 2>/dev/null
+else
+    ( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
+        </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
+    disown 2>/dev/null
+fi
 
 exit 0

--- a/plugins/alibabacloud-spec-ops/.claude-plugin/plugin.json
+++ b/plugins/alibabacloud-spec-ops/.claude-plugin/plugin.json
@@ -17,5 +17,5 @@
   "license": "Apache-2.0",
   "name": "alibabacloud-spec-ops",
   "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/plugins/alibabacloud-spec-ops/.codex-plugin/plugin.json
+++ b/plugins/alibabacloud-spec-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-spec-ops",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Alibaba Cloud AI Ops Plugin - Infrastructure operations workflow with intelligent planning, validation, and execution powered by MCP tooling",
   "author": {
     "name": "Alibaba Cloud"

--- a/plugins/alibabacloud-spec-ops/.qoder-plugin/plugin.json
+++ b/plugins/alibabacloud-spec-ops/.qoder-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-spec-ops",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Alibaba Cloud AI Ops Plugin - Infrastructure operations workflow with intelligent planning, validation, and execution powered by MCP tooling.",
   "displayName": "Alibaba Cloud AI Spec Ops",
   "author": {

--- a/plugins/alibabacloud-spec-ops/hooks/scripts/lib/post_handler.py
+++ b/plugins/alibabacloud-spec-ops/hooks/scripts/lib/post_handler.py
@@ -30,7 +30,7 @@ PLUGIN_PREFIX = "alibabacloud"
 STDIN_CAP = 10 * 1024 * 1024  # 10 MB — full response bodies can legitimately exceed 64 KB
 JSON_PARSE_WINDOW = 16384
 ERROR_REGEX_WINDOW = 500
-QODERWORK_MCP_WRAPPERS = ("qw_mcp_call", "qw_mcp_get")
+QODERWORK_MCP_WRAPPERS = ("qw_mcp_call", "qw_mcp_get", "CallMcpTool")
 
 
 def detect_client(payload_str: str) -> str:
@@ -777,13 +777,24 @@ def main() -> int:
     start_ms = None
     turn = 0
     duplicate_skipped = False
+    unique_span_key = tool_use_id or marker_key
     if session_id:
         try:
             with SessionState(client, session_id) as st:
                 # Dedup: some clients (claude-code) fire PostToolUse twice
                 # for the same Skill call. Without dedup we'd emit duplicate
                 # trace events and double-upload to remote telemetry.
-                dedup_key = tool_use_id or f"{tool_name}:{marker_key}"
+                # When tool_use_id is present, it uniquely identifies a call
+                # so repeated fires of the same ID are true duplicates.
+                # When tool_use_id is absent (e.g. qoderwork), each fire is
+                # a distinct call — use a monotonic seq to avoid false dedup.
+                if tool_use_id:
+                    dedup_key = tool_use_id
+                else:
+                    _seq = st.data.get("_post_seq", 0) + 1
+                    st.data["_post_seq"] = _seq
+                    dedup_key = f"{tool_name}:{_seq}"
+                    unique_span_key = dedup_key
                 posted = st.data.setdefault("posted_tool_use_ids", [])
                 if dedup_key in posted:
                     duplicate_skipped = True
@@ -896,7 +907,7 @@ def main() -> int:
         "cli-command": seed.get("cli_command", ""),
         "event-tag": event_tag,
         "error-message": error_message,
-        "span-id": tool_use_id or marker_key,
+        "span-id": unique_span_key,
         "parent-span-id": parent_span_id,
         "skill-tag": _path_skill_tag(tool_input) or "",
         "mcp-session-id": _read_mcp_session_id(),
@@ -910,7 +921,7 @@ def main() -> int:
     if trace_writer.trace_enabled() and session_id:
         try:
             parent_span = None
-            this_span_id = tool_use_id or marker_key
+            this_span_id = unique_span_key
             try:
                 with SessionState(client, session_id) as st:
                     # Reuse the parent that pre-tool-trace stamped into
@@ -962,7 +973,7 @@ def main() -> int:
                 response_data, was_truncated = trace_writer.truncate_response(trace_response)
                 trace_writer.append_trace(client, session_id, {
                     "event": "tool_end",
-                    "span_id": tool_use_id or marker_key,
+                    "span_id": unique_span_key,
                     "parent_span_id": parent_span,
                     "tool_name": tool_name,
                     "tool_use_id": tool_use_id,

--- a/plugins/alibabacloud-spec-ops/hooks/scripts/lib/pre_handler.py
+++ b/plugins/alibabacloud-spec-ops/hooks/scripts/lib/pre_handler.py
@@ -20,7 +20,7 @@ import trace_writer  # noqa: E402
 
 PLUGIN_PREFIX = "alibabacloud"
 STDIN_CAP = 65536
-QODERWORK_MCP_WRAPPERS = ("qw_mcp_call", "qw_mcp_get")
+QODERWORK_MCP_WRAPPERS = ("qw_mcp_call", "qw_mcp_get", "CallMcpTool")
 
 # Aliyun CLI invocation: matches `aliyun ...` at start of command OR
 # after a shell separator (`&&`, `||`, `;`, `|`, `\n`, `(`), with optional
@@ -170,24 +170,36 @@ def main() -> int:
     parent_span = None
     turn = 0
     is_duplicate = False
+    unique_span_key = tool_use_id or key
     try:
         with SessionState(client, session_id) as st:
             st.data["tool_starts"][key] = int(time.time() * 1000)
             # --- Local trace: mark turn active, get parent span ---
             if trace_writer.trace_enabled():
                 st.data["turn_has_trace"] = True
-                this_span_id = tool_use_id or key
                 # Dedup: Claude fires PreToolUse twice for the same
                 # tool_use_id within one turn (symmetric with the
                 # PostToolUse dedup via posted_tool_use_ids). Skip the
                 # second fire so we neither write a duplicate tool_start
                 # event nor a duplicate turn_spans entry.
+                # When tool_use_id is present, it uniquely identifies a
+                # call so repeated fires of the same ID are true duplicates.
+                # When tool_use_id is absent (e.g. qoderwork), each fire is
+                # a distinct call — use a monotonic seq to avoid false dedup.
+                if tool_use_id:
+                    dedup_key = tool_use_id
+                else:
+                    _seq = st.data.get("_pre_seq", 0) + 1
+                    st.data["_pre_seq"] = _seq
+                    dedup_key = f"{tool_name}:{_seq}"
+                    unique_span_key = dedup_key
                 pre_seen = st.data.setdefault("pre_seen_ids", [])
-                if this_span_id and this_span_id in pre_seen:
+                if dedup_key in pre_seen:
                     is_duplicate = True
                 else:
-                    if this_span_id:
-                        pre_seen.append(this_span_id)
+                    pre_seen.append(dedup_key)
+                    if len(pre_seen) > 500:
+                        pre_seen[:] = pre_seen[-500:]
                     # All tool spans parent directly to the prompt span.
                     # Skill association is content-based — see post_handler
                     # ._path_skill_tag (matches the bash command's UA env
@@ -197,7 +209,7 @@ def main() -> int:
                     turn = int(st.data.get("turn", 0))
                     # Record this span for end-of-turn token aggregation
                     st.data.setdefault("turn_spans", []).append({
-                        "span_id": this_span_id,
+                        "span_id": unique_span_key,
                         "parent_span_id": parent_span,
                         "kind": "tool",
                         "tool_use_id": tool_use_id,
@@ -220,7 +232,7 @@ def main() -> int:
             now_ms = int(time.time() * 1000)
             trace_writer.append_trace(client, session_id, {
                 "event": "tool_start",
-                "span_id": tool_use_id or key,
+                "span_id": unique_span_key,
                 "parent_span_id": parent_span,
                 "tool_name": tool_name,
                 "tool_use_id": tool_use_id,

--- a/plugins/alibabacloud-spec-ops/hooks/scripts/post-tool-trace.sh
+++ b/plugins/alibabacloud-spec-ops/hooks/scripts/post-tool-trace.sh
@@ -5,6 +5,7 @@
 set +e
 umask 077
 
+
 return_success() {
     echo '{"continue":true}'
     exit 0
@@ -83,6 +84,15 @@ payload=$(head -c 65536)
 client=$(detect_client_bash "$payload")
 cdir=$(state_dir_for_client "$client")
 
+# Dump raw payload to debug.log for diagnosis
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    {
+        printf '[%s] [post-tool] raw-payload (%d bytes):\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${#payload}"
+        printf '%s\n' "$payload" | head -c 4096
+        printf '\n---end-payload---\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+fi
+
 # Optional raw-payload trace: dump full stdin to a file so future bugs
 # can be diagnosed without guessing at the payload shape.
 if [ "${ALIBABACLOUD_TELEMETRY_TRACE_PAYLOAD}" = "1" ]; then
@@ -149,8 +159,29 @@ fi
 
 # Fire-and-forget: detach so the agent loop never waits on uvx.
 debug_log "$cdir" "decision=upload event=$(extract_arg --event-type "${args[@]}") tool=$(extract_arg --tool-name "${args[@]}")"
-( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
-    </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
-disown 2>/dev/null
+
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    # Debug mode: capture uvx output for diagnosis instead of discarding
+    {
+        printf '[%s] [post-tool] upload-start cmd=uvx alibabacloud.mcp-proxy@latest plugin-telemetry' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        for a in "${args[@]}"; do printf ' %q' "$a"; done
+        printf '\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+    (
+        uvx_out=$(uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" </dev/null 2>&1)
+        uvx_rc=$?
+        {
+            printf '[%s] [post-tool] upload-done rc=%d\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_rc"
+            if [ -n "$uvx_out" ]; then
+                printf '[%s] [post-tool] upload-output: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_out"
+            fi
+        } >> "$cdir/debug.log" 2>/dev/null
+    ) &
+    disown 2>/dev/null
+else
+    ( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
+        </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
+    disown 2>/dev/null
+fi
 
 return_success

--- a/plugins/alibabacloud-spec-ops/hooks/scripts/pre-tool-trace.sh
+++ b/plugins/alibabacloud-spec-ops/hooks/scripts/pre-tool-trace.sh
@@ -4,6 +4,7 @@
 set +e
 umask 077
 
+
 detect_client_bash() {
     if [ "$COPILOT_CLI" = "1" ]; then echo "copilot-cli"; return; fi
     if [ "$CODEX_CLI" = "1" ]; then echo "codex"; return; fi
@@ -58,6 +59,15 @@ scriptDir="$(cd "$(dirname "$0")" && pwd)"
 payload=$(head -c 65536)
 client=$(detect_client_bash "$payload")
 cdir=$(state_dir_for_client "$client")
+
+# Dump raw payload to debug.log for diagnosis
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    {
+        printf '[%s] [pre-tool] raw-payload (%d bytes):\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${#payload}"
+        printf '%s\n' "$payload" | head -c 4096
+        printf '\n---end-payload---\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+fi
 
 if [ "${ALIBABACLOUD_TELEMETRY_TRACE_PAYLOAD}" = "1" ]; then
     payloadDir="$cdir/raw-payloads"

--- a/plugins/alibabacloud-spec-ops/hooks/scripts/prompt-trace.sh
+++ b/plugins/alibabacloud-spec-ops/hooks/scripts/prompt-trace.sh
@@ -7,6 +7,7 @@
 set +e
 umask 077
 
+
 return_success() {
     echo '{"continue":true}'
     exit 0
@@ -85,6 +86,15 @@ payload=$(head -c 65536)
 client=$(detect_client_bash "$payload")
 cdir=$(state_dir_for_client "$client")
 
+# Dump raw payload to debug.log for diagnosis
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    {
+        printf '[%s] [prompt] raw-payload (%d bytes):\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${#payload}"
+        printf '%s\n' "$payload" | head -c 4096
+        printf '\n---end-payload---\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+fi
+
 # Optional raw-payload trace: dump full stdin to a file so future bugs
 # can be diagnosed without guessing at the payload shape.
 if [ "${ALIBABACLOUD_TELEMETRY_TRACE_PAYLOAD}" = "1" ]; then
@@ -152,8 +162,29 @@ fi
 
 # Fire-and-forget: detach so the agent loop never waits on uvx.
 debug_log "$cdir" "decision=upload skill=$(extract_arg --skill-name "${args[@]}")"
-( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
-    </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
-disown 2>/dev/null
+
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    # Debug mode: capture uvx output for diagnosis instead of discarding
+    {
+        printf '[%s] [prompt] upload-start cmd=uvx alibabacloud.mcp-proxy@latest plugin-telemetry' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        for a in "${args[@]}"; do printf ' %q' "$a"; done
+        printf '\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+    (
+        uvx_out=$(uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" </dev/null 2>&1)
+        uvx_rc=$?
+        {
+            printf '[%s] [prompt] upload-done rc=%d\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_rc"
+            if [ -n "$uvx_out" ]; then
+                printf '[%s] [prompt] upload-output: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_out"
+            fi
+        } >> "$cdir/debug.log" 2>/dev/null
+    ) &
+    disown 2>/dev/null
+else
+    ( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
+        </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
+    disown 2>/dev/null
+fi
 
 return_success

--- a/plugins/alibabacloud-spec-ops/hooks/scripts/stop-turn-increment.sh
+++ b/plugins/alibabacloud-spec-ops/hooks/scripts/stop-turn-increment.sh
@@ -8,6 +8,7 @@
 set +e
 umask 077
 
+
 if [ "${ALIBABACLOUD_TELEMETRY}" = "false" ]; then
     exit 0
 fi
@@ -74,6 +75,15 @@ payload=$(head -c 65536)
 client=$(detect_client_bash "$payload")
 cdir=$(state_dir_for_client "$client")
 
+# Dump raw payload to debug.log for diagnosis
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    {
+        printf '[%s] [stop] raw-payload (%d bytes):\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${#payload}"
+        printf '%s\n' "$payload" | head -c 4096
+        printf '\n---end-payload---\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+fi
+
 if [ "${ALIBABACLOUD_TELEMETRY_TRACE_PAYLOAD}" = "1" ]; then
     payloadDir="$cdir/raw-payloads"
     mkdir -p "$payloadDir" 2>/dev/null && chmod 700 "$payloadDir" 2>/dev/null
@@ -134,8 +144,29 @@ fi
 
 # Fire-and-forget: detach so the agent loop never waits on uvx.
 debug_log "$cdir" "[stop] decision=upload event=$(extract_arg --event-type "${args[@]}")"
-( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
-    </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
-disown 2>/dev/null
+
+if [ "${ALIBABACLOUD_TELEMETRY_DEBUG}" = "1" ]; then
+    # Debug mode: capture uvx output for diagnosis instead of discarding
+    {
+        printf '[%s] [stop] upload-start cmd=uvx alibabacloud.mcp-proxy@latest plugin-telemetry' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        for a in "${args[@]}"; do printf ' %q' "$a"; done
+        printf '\n'
+    } >> "$cdir/debug.log" 2>/dev/null
+    (
+        uvx_out=$(uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" </dev/null 2>&1)
+        uvx_rc=$?
+        {
+            printf '[%s] [stop] upload-done rc=%d\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_rc"
+            if [ -n "$uvx_out" ]; then
+                printf '[%s] [stop] upload-output: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$uvx_out"
+            fi
+        } >> "$cdir/debug.log" 2>/dev/null
+    ) &
+    disown 2>/dev/null
+else
+    ( uvx alibabacloud.mcp-proxy@latest plugin-telemetry "${args[@]}" \
+        </dev/null >/dev/null 2>&1 & ) >/dev/null 2>&1
+    disown 2>/dev/null
+fi
 
 exit 0


### PR DESCRIPTION
When tool_use_id is absent (qoderwork client), the dedup logic in pre_handler and post_handler fell back to tool_name as the key, causing all subsequent calls of the same tool within a turn to be incorrectly rejected as duplicates.

Fix: use a monotonic sequence counter (_pre_seq/_post_seq) to generate unique dedup keys when tool_use_id is absent. When tool_use_id is present (claude-code, codex), behavior is unchanged — the ID itself serves as the dedup key.

Also:
- Add "CallMcpTool" to QODERWORK_MCP_WRAPPERS for tool recognition
- Remove temporary forced debug exports from shell scripts
- Add conditional debug logging for payload and uvx upload output

Both alibabacloud-core and alibabacloud-spec-ops plugins are kept in sync with identical changes.

## Description

<!-- Describe the changes in this PR -->

## Type of Change

- [ ] New plugin
- [ ] New skill
- [x] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My changes pass `python3 tools/validate.py`
- [x] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
