### PR TITLE
fix: remove unsupported skills field from qoder plugin.json

### DIFF
--- a/plugins/alibabacloud-core/.claude-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.claude-plugin/plugin.json
@@ -11,5 +11,5 @@
   "license": "Apache-2.0",
   "name": "alibabacloud-core",
   "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
-  "version": "1.0.18"
+  "version": "1.0.19"
 }

--- a/plugins/alibabacloud-core/.codex-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-core",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Core Alibaba Cloud plugin for OpenAPI SDK code generation through a constrained MCP server.",
   "author": {
     "name": "Alibaba Cloud"

--- a/plugins/alibabacloud-core/.qoder-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.qoder-plugin/plugin.json
@@ -13,7 +13,6 @@
   "homepage": "https://github.com/aliyun/alibabacloud-agent-toolkit",
   "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
   "license": "Apache-2.0",
-  "skills": "./skills/",
   "hooks": "./hooks/qoderwork-hooks.json",
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/alibabacloud-core/.qoder-plugin/plugin.json
+++ b/plugins/alibabacloud-core/.qoder-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-core",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Core Alibaba Cloud plugin for OpenAPI SDK code generation through a constrained MCP server.",
   "displayName": "Alibaba Cloud Core",
   "author": {

--- a/plugins/alibabacloud-spec-ops/.claude-plugin/plugin.json
+++ b/plugins/alibabacloud-spec-ops/.claude-plugin/plugin.json
@@ -17,5 +17,5 @@
   "license": "Apache-2.0",
   "name": "alibabacloud-spec-ops",
   "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/plugins/alibabacloud-spec-ops/.codex-plugin/plugin.json
+++ b/plugins/alibabacloud-spec-ops/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-spec-ops",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Alibaba Cloud AI Ops Plugin - Infrastructure operations workflow with intelligent planning, validation, and execution powered by MCP tooling",
   "author": {
     "name": "Alibaba Cloud"

--- a/plugins/alibabacloud-spec-ops/.qoder-plugin/plugin.json
+++ b/plugins/alibabacloud-spec-ops/.qoder-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-spec-ops",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Alibaba Cloud AI Ops Plugin - Infrastructure operations workflow with intelligent planning, validation, and execution powered by MCP tooling.",
   "displayName": "Alibaba Cloud AI Spec Ops",
   "author": {

--- a/plugins/alibabacloud-spec-ops/.qoder-plugin/plugin.json
+++ b/plugins/alibabacloud-spec-ops/.qoder-plugin/plugin.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/aliyun/alibabacloud-agent-toolkit",
   "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
   "license": "Apache-2.0",
-  "skills": "./skills/",
   "agents": "./agents/",
   "hooks": "./hooks/qoderwork-hooks.json",
   "mcpServers": "./.mcp.json"


### PR DESCRIPTION
## Summary
- Remove `"skills": "./skills/"` from `alibabacloud-core/.qoder-plugin/plugin.json`
- Remove `"skills": "./skills/"` from `alibabacloud-spec-ops/.qoder-plugin/plugin.json`

The qoder client does not support the `skills` field declaration, causing plugin installation failures for end users.

## Test plan
- [x] Verify qoder client can install alibabacloud-core plugin successfully
- [x] Verify qoder client can install alibabacloud-spec-ops plugin successfully

(created by caihe-agent)