### PR TITLE
fix(plugins): point alibabacloud-ecs-ops metadata at this repository

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -47,7 +47,7 @@
       ],
       "name": "alibabacloud-ecs-ops",
       "source": "./plugins/alibabacloud-ecs-ops",
-      "version": "0.0.8"
+      "version": "0.0.9"
     }
   ]
 }

--- a/plugins/alibabacloud-ecs-ops/.claude-plugin/plugin.json
+++ b/plugins/alibabacloud-ecs-ops/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
     "name": "Alibaba Cloud"
   },
   "description": "Alibaba Cloud ECS 全生命周期运维管理插件，覆盖实例管理、诊断排障、磁盘快照、安全组网络及场景化运维，集成操作前成本评估能力",
-  "homepage": "https://github.com/acloudlabs-unofficial/agent-plugins",
+  "homepage": "https://github.com/aliyun/alibabacloud-agent-toolkit",
   "keywords": [
     "alibabacloud",
     "aliyun",
@@ -12,6 +12,6 @@
   ],
   "license": "Apache-2.0",
   "name": "alibabacloud-ecs-ops",
-  "repository": "https://github.com/acloudlabs-unofficial/agent-plugins",
-  "version": "0.0.8"
+  "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
+  "version": "0.0.9"
 }

--- a/plugins/alibabacloud-ecs-ops/.codex-plugin/plugin.json
+++ b/plugins/alibabacloud-ecs-ops/.codex-plugin/plugin.json
@@ -3,7 +3,7 @@
     "name": "Alibaba Cloud"
   },
   "description": "Alibaba Cloud ECS 全生命周期运维管理插件，覆盖实例管理、诊断排障、磁盘快照、安全组网络及场景化运维，集成操作前成本评估能力",
-  "homepage": "https://github.com/acloudlabs-unofficial/agent-plugins",
+  "homepage": "https://github.com/aliyun/alibabacloud-agent-toolkit",
   "interface": {
     "displayName": "Alibaba Cloud ECS Ops",
     "shortDescription": "Alibaba Cloud ECS full-lifecycle operations management",
@@ -14,7 +14,7 @@
       "Read",
       "Write"
     ],
-    "websiteURL": "https://github.com/acloudlabs-unofficial/agent-plugins",
+    "websiteURL": "https://github.com/aliyun/alibabacloud-agent-toolkit",
     "defaultPrompt": [
       "Inspect my ECS resources and recommend the next operational action."
     ]
@@ -27,6 +27,6 @@
   ],
   "license": "Apache-2.0",
   "name": "alibabacloud-ecs-ops",
-  "repository": "https://github.com/acloudlabs-unofficial/agent-plugins",
-  "version": "0.0.8"
+  "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
+  "version": "0.0.9"
 }

--- a/plugins/alibabacloud-ecs-ops/.qoder-plugin/plugin.json
+++ b/plugins/alibabacloud-ecs-ops/.qoder-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "alibabacloud-ecs-ops",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Alibaba Cloud ECS 全生命周期运维管理插件，覆盖实例管理、诊断排障、磁盘快照、安全组网络及场景化运维，集成操作前成本评估能力",
   "displayName": "Alibaba Cloud ECS Ops",
   "author": {
@@ -12,8 +12,8 @@
     "ecs",
     "ops"
   ],
-  "homepage": "https://github.com/acloudlabs-unofficial/agent-plugins",
-  "repository": "https://github.com/acloudlabs-unofficial/agent-plugins",
+  "homepage": "https://github.com/aliyun/alibabacloud-agent-toolkit",
+  "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
   "license": "Apache-2.0",
   "hooks": "./hooks/qoderwork-hooks.json",
   "mcpServers": "./.mcp.json"

--- a/plugins/alibabacloud-ecs-ops/README.md
+++ b/plugins/alibabacloud-ecs-ops/README.md
@@ -7,7 +7,7 @@ Alibaba Cloud ECS 全生命周期运维管理插件，覆盖实例管理、诊�
 ### One-command install (recommended)
 
 ```bash
-npx openplugin acloudlabs-unofficial/agent-plugins
+npx openplugin aliyun/alibabacloud-agent-toolkit --plugin alibabacloud-ecs-ops
 ```
 
 ### Manual install
@@ -15,15 +15,15 @@ npx openplugin acloudlabs-unofficial/agent-plugins
 #### Claude Code
 
 ```text
-/plugin marketplace add acloudlabs-unofficial/agent-plugins
-/plugin install alibabacloud-ecs-ops@agent-plugins
+/plugin marketplace add aliyun/alibabacloud-agent-toolkit
+/plugin install alibabacloud-ecs-ops@alibabacloud-agent-toolkit
 /reload-plugins
 ```
 
 #### Codex
 
 ```text
-codex plugin marketplace add acloudlabs-unofficial/agent-plugins
+codex plugin marketplace add aliyun/alibabacloud-agent-toolkit
 ```
 
 ## MCP Configuration

--- a/plugins/alibabacloud-ecs-ops/openclaw.plugin.json
+++ b/plugins/alibabacloud-ecs-ops/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "alibabacloud-ecs-ops",
   "name": "alibabacloud-ecs-ops",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Alibaba Cloud ECS 全生命周期运维管理插件，覆盖实例管理、诊断排障、磁盘快照、安全组网络及场景化运维，集成操作前成本评估能力",
   "configSchema": {
     "type": "object",

--- a/plugins/alibabacloud-ecs-ops/plugin.json
+++ b/plugins/alibabacloud-ecs-ops/plugin.json
@@ -4,7 +4,7 @@
     "name": "Alibaba Cloud"
   },
   "description": "Alibaba Cloud ECS 全生命周期运维管理插件，覆盖实例管理、诊断排障、磁盘快照、安全组网络及场景化运维，集成操作前成本评估能力",
-  "homepage": "https://github.com/acloudlabs-unofficial/agent-plugins",
+  "homepage": "https://github.com/aliyun/alibabacloud-agent-toolkit",
   "keywords": [
     "alibabacloud",
     "aliyun",
@@ -13,6 +13,6 @@
   ],
   "license": "Apache-2.0",
   "name": "alibabacloud-ecs-ops",
-  "repository": "https://github.com/acloudlabs-unofficial/agent-plugins",
-  "version": "0.0.8"
+  "repository": "https://github.com/aliyun/alibabacloud-agent-toolkit",
+  "version": "0.0.9"
 }

--- a/tools/test_validate.py
+++ b/tools/test_validate.py
@@ -157,13 +157,25 @@ class EcsManifestTests(unittest.TestCase):
             json.loads(path.read_text(encoding="utf-8"))["version"]
             for path in paths
         }
-        self.assertEqual({"0.0.8"}, versions)
+        self.assertEqual({"0.0.9"}, versions)
 
     def test_marketplace_version_matches(self) -> None:
         marketplace = repo_validate.REPO_ROOT / ".claude-plugin/marketplace.json"
         entries = json.loads(marketplace.read_text(encoding="utf-8"))["plugins"]
         entry = next(e for e in entries if e["name"] == "alibabacloud-ecs-ops")
-        self.assertEqual("0.0.8", entry["version"])
+        self.assertEqual("0.0.9", entry["version"])
+
+    def test_manifests_point_at_this_repository(self) -> None:
+        plugin_dir = repo_validate.REPO_ROOT / "plugins/alibabacloud-ecs-ops"
+        expected = "https://github.com/aliyun/alibabacloud-agent-toolkit"
+        declared = {}
+        for manifest in repo_validate.PLUGIN_VERSION_MANIFESTS:
+            path = plugin_dir / manifest
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if "repository" in data:
+                declared[manifest] = data["repository"]
+        self.assertTrue(declared)
+        self.assertEqual(set(declared.values()), {expected})
 
     def test_qoder_manifest_declares_hooks_and_mcp(self) -> None:
         path = repo_validate.REPO_ROOT / "plugins/alibabacloud-ecs-ops/.qoder-plugin/plugin.json"


### PR DESCRIPTION
The ecs-ops manifests declared repository, homepage and interface.websiteURL as https://github.com/acloudlabs-unofficial/agent-plugins, an unrelated external repository, and the plugin README told users to install from that same marketplace, so the documented install path could not resolve this plugin.

Point every one of those fields at
https://github.com/aliyun/alibabacloud-agent-toolkit, matching the convention alibabacloud-core and alibabacloud-spec-ops already follow, and correct the README install commands to the real marketplace name.

Bump the plugin to 0.0.9 across the six manifests that tools/validate.py:validate_version_consistency keeps in agreement, update the two pinned version assertions in tools/test_validate.py, and add a regression test guarding the repository field.

## Description

<!-- Describe the changes in this PR -->

## Type of Change

- [ ] New plugin
- [ ] New skill
- [ ] Bug fix
- [ ] Documentation update
- [ ] CI/CD change
- [ ] Other

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] My changes pass `python3 tools/validate.py`
- [ ] I have updated relevant documentation

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
